### PR TITLE
Fix "toggle comment" using invalid Firestore syntax

### DIFF
--- a/settings/firestore.cson
+++ b/settings/firestore.cson
@@ -1,0 +1,4 @@
+'.source.firestore':
+  editor:
+    # Allow toggling comments with cmd+/
+    commentStart: '// '


### PR DESCRIPTION
Atom uses `/* */` block as default comment block for Firestore grammar, but this is invalid. This PR changes the default behaviour to use the valid `// ` block. 👍